### PR TITLE
Stevo_lib Checker Version Removed

### DIFF
--- a/resource/client.lua
+++ b/resource/client.lua
@@ -1,4 +1,3 @@
-if not lib.checkDependency('stevo_lib', '1.6.9') then error('stevo_lib 1.6.9 required for stevo_fruitpicking') end
 lib.locale()
 local config = require('config')
 local stevo_lib = exports['stevo_lib']:import()

--- a/resource/server.lua
+++ b/resource/server.lua
@@ -1,5 +1,3 @@
-if not lib.checkDependency('stevo_lib', '1.6.9') then error('stevo_lib 1.6.9 required for stevo_fruitpicking') end
-lib.versionCheck('stevoscriptsteam/stevo_fruitpicking')
 lib.locale()
 local stevo_lib = exports['stevo_lib']:import()
 local config = lib.require('config')


### PR DESCRIPTION
Removed function to check stevo_lib-1.6.8 (too old) so that players can just install stevo_lib 1.7.6 and plug and play